### PR TITLE
feat(api/routing): routes index and users, users controller

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import express, {Application, NextFunction, Response, Request} from 'express';
 import morgan from 'morgan';
 import config from "../config"
-import routes from "./routes/index"
+import {router} from "./routes/index"
 
 const app: Application = express();
 app.use(express.urlencoded({extended: true, limit: '50mb'})); //middleware
@@ -20,6 +20,8 @@ app.use(
  })
 );
 
+app.use('/api', router)
+
 interface error{
     status: number;
     message: string;
@@ -32,8 +34,6 @@ app.use((err: error, req: Request, res: Response, next: NextFunction) => {
  console.error(err);
  res.status(status).send(message);
 });
-
-app.use("/",routes)
 
 
 export default app;

--- a/api/src/controllers/users.ts
+++ b/api/src/controllers/users.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from "express"
+
+export const getUsers = (req: Request,res: Response,next:NextFunction) => {
+  res.send({list: [1,2,3]})
+
+}
+export const getUser = (req: Request,res: Response,next:NextFunction) => {
+
+}
+export const createUser = (req: Request,res: Response,next:NextFunction) => {
+
+}
+export const deleteUser = (req: Request,res: Response,next:NextFunction) => {
+
+}
+
+

--- a/api/src/models/User.ts
+++ b/api/src/models/User.ts
@@ -1,5 +1,5 @@
-import {Model, Column, Table, HasMany} from 'sequelize-typescript'
-import {Ticket} from './Ticket'
+import {Model, Column, Table, HasMany} from 'sequelize-typescript';
+import {Ticket} from './Ticket';
 
 @Table
 export class User extends Model<User>{

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -1,9 +1,20 @@
 import {Router} from "express"
+import fs from 'fs'
+export const router = Router()
+
+const pathRouter = `${__dirname}`
+
+// Remove extension from routes files
+const removeExtension = (fileName:string) : string | undefined => fileName.split('.').shift();
+
+// Remove index file from routes files and dynamically import the current route and it's controller
+fs.readdirSync(pathRouter).filter(async file => {
+  const fileWWithOutExt : string | undefined = removeExtension(file)
+  let skip: boolean;
+  fileWWithOutExt ? skip = ['index'].includes(fileWWithOutExt) : skip = false
+  if (!skip) {
+    import(`./${fileWWithOutExt}`).then(module => router.use(`/${fileWWithOutExt}`, module.router))
+    console.log('LOAD ROUTE --->', fileWWithOutExt)}
+})
 
 
-const routes = Router()
-
-
-
-
-export default routes

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -1,0 +1,8 @@
+import {Router} from 'express'
+export const router = Router();
+import {getUsers,getUser,createUser,deleteUser} from '../controllers/users'
+
+router.get('/', getUsers)
+router.get('/:id', getUser)
+router.post('/', createUser)
+router.delete('/:id', deleteUser)


### PR DESCRIPTION
-- Index del routing, es escalable a la cantidad de routers que querramos hacer. Lo que hace la función es escanear todos los archivos que hay en el directorio /api/src/routes, removerles las extensiones, sacar de la lista al index e importar dinámicamente a uno u otro dependiendo de la ruta en donde se haga la petición.
-- Rutas de prueba en routes/users.ts y controladores básicos en controllers/users.ts

--En el app.ts cambie el app.use que había por el nuevo que utiliza al router principal de index.