### PR TITLE
fix(api/authentication): cors, accessToken expiration and handleRefre…

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -17,7 +17,7 @@ app.use(
   origin: config.cors,
   credentials: true,
   methods: ['GET', 'POST', 'OPTIONS', 'PUT', 'DELETE'],
-  allowedHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept'],
+  allowedHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept', 'Authorization', 'authorization'],
  })
 );
 

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -40,7 +40,7 @@ export const handleRefreshToken = async (req: Request, res: Response, next: Next
     const user = await getUserFromDbByField('refreshToken',refreshToken);
     if (!user) return next({status:403 , message:'Not Allowed'})
     let newToken = verifyRefreshToken(user);
-    if (typeof newToken === 'string') res.send({newToken})
+    if (typeof newToken === 'string') res.send({accessToken:newToken})
     else throw newToken   // obj error {status, message}
   }catch(error){return next(error)}
 }

--- a/api/src/utils/auth.ts
+++ b/api/src/utils/auth.ts
@@ -11,7 +11,7 @@ export function generateAccessToken(user: iUser){
       'email': user.email,
       'rolesId':user.rolesId
     }
-  }, process.env.ACCESS_TOKEN_SECRET as string, {expiresIn: '30m'})
+  }, process.env.ACCESS_TOKEN_SECRET as string, {expiresIn: '10m'})
 }
 
 export async function updateRefreshToken(user: iUser, errase: boolean = false){


### PR DESCRIPTION
…shToken

Arregle el cors para que acepte peticiones con el header authorization (requerido para la autenticación en el front)

Cambie el tiempo de expiración del accessToken de 30m a 10m, se refreshea automáticamente en el front cuando se consume.

handleRefreshToken estaba enviando un nuevo token con el nombre newToken, para que haya coherencia en el front en como se recibe se cambió a accessToken igual que el accessToken inicial.