### PR TITLE
Feat/update ticket

### DIFF
--- a/api/src/controllers/process-payment.ts
+++ b/api/src/controllers/process-payment.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from "express"
-import { createPreference } from "../utils/process-payment"
+import { createPreference, updatePaymentById } from "../utils/process-payment"
 import utils from "../utils/event"
 import { createTickets } from "../utils/tickets"
 
@@ -32,5 +32,15 @@ export const process_payment = (req: Request,res: Response,next:NextFunction) =>
     }catch(error){
         next(error)
     }
-
 }
+
+export const updatePayment = async (req: Request, res: Response, next: NextFunction) => {
+    try{
+        const {preferenceId, paymentId} = req.body
+        const ticket = await updatePaymentById(preferenceId, paymentId)
+
+        res.status(200).json(ticket)
+    }catch(error){
+        next(error)
+    }
+} 

--- a/api/src/controllers/process-payment.ts
+++ b/api/src/controllers/process-payment.ts
@@ -36,10 +36,12 @@ export const process_payment = (req: Request,res: Response,next:NextFunction) =>
 
 export const updatePayment = async (req: Request, res: Response, next: NextFunction) => {
     try{
-        const {preferenceId, paymentId} = req.body
-        const ticket = await updatePaymentById(preferenceId, paymentId)
+        const preference_id = req.query.preference_id as string
+        const payment_id = req.query.payment_id as string
+        
+        await updatePaymentById(preference_id, payment_id)
 
-        res.status(200).json(ticket)
+        res.redirect("http://localhost:3000")
     }catch(error){
         next(error)
     }

--- a/api/src/controllers/ticket.ts
+++ b/api/src/controllers/ticket.ts
@@ -1,5 +1,5 @@
 import { Response, Request, NextFunction } from "express";
-import { getTicketFromDb, updateTicket} from "../utils/ticket"
+import { getTicketFromDb} from "../utils/ticket"
 
 export const getTicket = async (req: Request, res: Response, next: NextFunction) => {
     try{
@@ -9,17 +9,6 @@ export const getTicket = async (req: Request, res: Response, next: NextFunction)
         if(!ticket) next({status: 404, message: "Ticket not found"})
         else res.status(200).json(ticket)
         
-    }catch(error){
-        next(error)
-    }
-} 
-
-export const putTicket = async (req: Request, res: Response, next: NextFunction) => {
-    try{
-        const {preferenceId, paymentId} = req.body
-        const ticket = await updateTicket(preferenceId, paymentId)
-
-        res.status(200).json(ticket)
     }catch(error){
         next(error)
     }

--- a/api/src/routes/process-payment.ts
+++ b/api/src/routes/process-payment.ts
@@ -5,4 +5,4 @@ import { authenticateToken } from "../middlewares/authenticateToken"
 export const router = Router()
 
 router.post('/', authenticateToken, process_payment)
-router.post("/update", updatePayment)
+router.get("/update", updatePayment)

--- a/api/src/routes/process-payment.ts
+++ b/api/src/routes/process-payment.ts
@@ -1,7 +1,8 @@
 import { Router } from "express"
-import { process_payment } from "../controllers/process-payment"
+import { process_payment, updatePayment } from "../controllers/process-payment"
 import { authenticateToken } from "../middlewares/authenticateToken"
 
 export const router = Router()
 
 router.post('/', authenticateToken, process_payment)
+router.post("/update", updatePayment)

--- a/api/src/routes/ticket.ts
+++ b/api/src/routes/ticket.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { ROLES_LIST } from "../authorization/roles"
-import { getTicket, putTicket } from '../controllers/ticket'
+import { getTicket } from '../controllers/ticket'
 import { authenticateToken } from "../middlewares/authenticateToken"
 import { verifyRoles } from "../middlewares/verifyRoles"
 
@@ -8,6 +8,6 @@ import { verifyRoles } from "../middlewares/verifyRoles"
 export const router = Router()
 
 router.get('/:id',authenticateToken, verifyRoles(ROLES_LIST.Admin), getTicket)
-router.put('/',authenticateToken, putTicket)
+
 
 

--- a/api/src/utils/process-payment.ts
+++ b/api/src/utils/process-payment.ts
@@ -1,5 +1,8 @@
 import mercadopago from "mercadopago"
 import config from "../../config"
+import { sequelize } from "../db"
+
+const { Ticket } = sequelize.models
 
 export const createPreference= (items:any, user: any) => {
 
@@ -19,11 +22,26 @@ export const createPreference= (items:any, user: any) => {
         },
         items,
         back_urls:{
-            success: "http://localhost:3000/",
+            success: "http://localhost:3001/",
             failure: "http://localhost:3000/",
             pending: "http://localhost:3000/"
         }
     })
 
     return preference
+}
+
+
+export const updatePaymentById = async(preferenceId: string, paymentId: string) => {
+    mercadopago.configure({
+        access_token: config.ACCESS_TOKEN
+    })
+
+    const {body}  = await mercadopago.payment.findById(Number(paymentId))
+
+    await Ticket.update({status: body.status , status_detail: body.status_detail , paymentId , paymentType: body.payment_type_id},{
+        where:{
+            preferenceId
+        }
+    })
 }

--- a/api/src/utils/process-payment.ts
+++ b/api/src/utils/process-payment.ts
@@ -22,9 +22,9 @@ export const createPreference= (items:any, user: any) => {
         },
         items,
         back_urls:{
-            success: "http://localhost:3001/",
-            failure: "http://localhost:3000/",
-            pending: "http://localhost:3000/"
+            success: "http://localhost:3001/api/process-payment/update",
+            failure: "http://localhost:3001/api/process-payment/update",
+            pending: "http://localhost:3001/api/process-payment/update"
         }
     })
 

--- a/api/src/utils/ticket.ts
+++ b/api/src/utils/ticket.ts
@@ -1,6 +1,4 @@
-import mercadopago from "mercadopago";
 import { sequelize } from "../db";
-import config from "../../config";
 
 const { Ticket } = sequelize.models
 
@@ -8,18 +6,4 @@ export const getTicketFromDb = async (id: string | number) => {
     const ticket = await Ticket.findByPk(id)
 
     return ticket
-}
-
-export const updateTicket = async(preferenceId: string, paymentId: string) => {
-    mercadopago.configure({
-        access_token: config.ACCESS_TOKEN
-    })
-
-    const {body}  = await mercadopago.payment.findById(Number(paymentId))
-
-    await Ticket.update({status: body.status , status_detail: body.status_detail , paymentId , paymentType: body.payment_type_id},{
-        where:{
-            preferenceId
-        }
-    })
 }


### PR DESCRIPTION
Se pasó el PUT /ticket que habia antes para actualizar un pago con datos de MercadoPago a la siguiente ruta

GET /process-payment/update

Hace la misma función que la anterior solo que los datos los pide por query "payment_id" y "preference_id" y ya no necesita de un token para poder hacer la petición