### PR TITLE
Feat/routes/request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,5 @@ dist
 
 # package-lock.json
 package-lock.json
+
+api/requests/*

--- a/api/nodemon.json
+++ b/api/nodemon.json
@@ -1,0 +1,3 @@
+{
+    "ignore": ["requests/*"]
+}

--- a/api/src/controllers/request.ts
+++ b/api/src/controllers/request.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { createRequest, updateRequest } from "../utils/request";
+import { createRequest, updateRequest, findRequest } from "../utils/request";
 
 export const postRequest = async (req: Request, res: Response, next: NextFunction) => {
     try{
@@ -19,10 +19,22 @@ export const putRequest = async (req: Request, res: Response, next: NextFunction
         const {status} = req.body
         const {id} = req.params
 
-
         await updateRequest(id,status)
 
         res.status(200).send("Request updated successfully")
+    }catch(error){
+        next(error)
+    }
+}
+
+export const getRequest = async (req: Request, res: Response, next: NextFunction) => {
+    try{
+        const {id} = req.params
+
+        const request = await findRequest(id)
+
+        if(!request) next({status:404, message: "Request not found"})
+        else res.status(200).send(request)
     }catch(error){
         next(error)
     }

--- a/api/src/controllers/request.ts
+++ b/api/src/controllers/request.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from "express";
+import { createRequest } from "../utils/request";
+
+export const postRequest = async (req: Request, res: Response, next: NextFunction) => {
+    try{
+        const {user, description, type, method, information } = req.body
+
+
+        await createRequest(user.id, description, type, method, information)
+
+        res.status(201).send("Request created successfully")
+    }catch(error){
+        next(error)
+    }
+}

--- a/api/src/controllers/request.ts
+++ b/api/src/controllers/request.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { createRequest } from "../utils/request";
+import { createRequest, updateRequest } from "../utils/request";
 
 export const postRequest = async (req: Request, res: Response, next: NextFunction) => {
     try{
@@ -9,6 +9,20 @@ export const postRequest = async (req: Request, res: Response, next: NextFunctio
         await createRequest(user.id, description, type, method, information)
 
         res.status(201).send("Request created successfully")
+    }catch(error){
+        next(error)
+    }
+}
+
+export const putRequest = async (req: Request, res: Response, next: NextFunction) => {
+    try{
+        const {status} = req.body
+        const {id} = req.params
+
+
+        await updateRequest(id,status)
+
+        res.status(200).send("Request updated successfully")
     }catch(error){
         next(error)
     }

--- a/api/src/routes/request.ts
+++ b/api/src/routes/request.ts
@@ -1,0 +1,8 @@
+import { Router } from "express"
+import { postRequest } from "../controllers/request"
+import { authenticateToken } from "../middlewares/authenticateToken"
+
+
+export const router = Router()
+
+router.post('/', authenticateToken, postRequest)

--- a/api/src/routes/request.ts
+++ b/api/src/routes/request.ts
@@ -1,11 +1,12 @@
 import { Router } from "express"
 import { ROLES_LIST } from "../authorization/roles"
-import { postRequest, putRequest } from "../controllers/request"
+import { postRequest, putRequest, getRequest } from "../controllers/request"
 import { authenticateToken } from "../middlewares/authenticateToken"
 import { verifyRoles } from "../middlewares/verifyRoles"
 
 
 export const router = Router()
 
+router.get("/:id", authenticateToken, verifyRoles(ROLES_LIST.Admin), getRequest)
 router.post('/', authenticateToken, postRequest)
 router.put("/:id", authenticateToken, verifyRoles(ROLES_LIST.Admin), putRequest)

--- a/api/src/routes/request.ts
+++ b/api/src/routes/request.ts
@@ -1,8 +1,11 @@
 import { Router } from "express"
-import { postRequest } from "../controllers/request"
+import { ROLES_LIST } from "../authorization/roles"
+import { postRequest, putRequest } from "../controllers/request"
 import { authenticateToken } from "../middlewares/authenticateToken"
+import { verifyRoles } from "../middlewares/verifyRoles"
 
 
 export const router = Router()
 
 router.post('/', authenticateToken, postRequest)
+router.put("/:id", authenticateToken, verifyRoles(ROLES_LIST.Admin), putRequest)

--- a/api/src/utils/request.ts
+++ b/api/src/utils/request.ts
@@ -4,7 +4,10 @@ import fs from "fs"
 const { Request } = sequelize.models
 
 enum list{
-    POST_organization = "createOrganization"
+    POST_organization = "createOrganization",
+    POST_location = "createLocation",
+    DELETE_event = "destroyEvent",
+    PUT_event = "updateEvent"
 }
 
 export const createRequest = async (userId: number, description: string, type: string, method: string, information: any) => {

--- a/api/src/utils/request.ts
+++ b/api/src/utils/request.ts
@@ -1,0 +1,20 @@
+import { sequelize } from "../db";
+import fs from "fs"
+const { Request } = sequelize.models
+
+export const createRequest = async (userId: number, description: string, type: string, method: string, information: any) => {
+
+    const request  = await Request.create({userId, description, type, method})
+
+    if (!fs.existsSync("./requests")){
+        fs.mkdirSync("./requests");
+    }
+
+    const url_body = `./requests/${request.getDataValue("id")}-${method}-${type}-.json`
+
+    fs.writeFile(url_body,JSON.stringify(information), "utf-8", (err) => {
+        if(err) throw err;
+    })
+
+    request.update({url_body})
+}

--- a/api/src/utils/request.ts
+++ b/api/src/utils/request.ts
@@ -18,3 +18,9 @@ export const createRequest = async (userId: number, description: string, type: s
 
     request.update({url_body})
 }
+
+export const updateRequest = async (id:string | number, status: string) => {
+    let request = await Request.findByPk(id)
+
+    request?.update({status})
+}

--- a/api/src/utils/request.ts
+++ b/api/src/utils/request.ts
@@ -1,7 +1,7 @@
 import { sequelize } from "../db";
 import { Model } from "sequelize";
 import fs from "fs"
-const { Request } = sequelize.models
+const { Request, User } = sequelize.models
 
 enum list{
     POST_organization = "createOrganization",
@@ -46,4 +46,15 @@ export const updateRequest = async (id:string | number, status: string) => {
         
         if(status === "accepted") executeRequest(request)
     }
+}
+
+export const findRequest = async (id: string | number) => {
+    let request = await Request.findByPk(id, {
+        include: {
+            model: User,
+            attributes: ["id","name","email"]
+        }
+    })
+
+    return request
 }

--- a/api/src/utils/request.ts
+++ b/api/src/utils/request.ts
@@ -1,16 +1,20 @@
 import { sequelize } from "../db";
+import { Model } from "sequelize";
 import fs from "fs"
 const { Request } = sequelize.models
 
+enum list{
+    POST_organization = "createOrganization"
+}
+
 export const createRequest = async (userId: number, description: string, type: string, method: string, information: any) => {
-
-    const request  = await Request.create({userId, description, type, method})
-
+    const request  = await Request.create({userId, description, type, method, function_type: list[`${method}_${type}` as keyof typeof list]})
+    
     if (!fs.existsSync("./requests")){
         fs.mkdirSync("./requests");
     }
-
-    const url_body = `./requests/${request.getDataValue("id")}-${method}-${type}-.json`
+    const id = request.getDataValue("id")
+    const url_body = `./requests/${id}_${method}_${type}.json`
 
     fs.writeFile(url_body,JSON.stringify(information), "utf-8", (err) => {
         if(err) throw err;
@@ -19,8 +23,24 @@ export const createRequest = async (userId: number, description: string, type: s
     request.update({url_body})
 }
 
+const executeRequest = (request: Model<any,any>) => {
+    const id = request.getDataValue("id")
+    const type = request.getDataValue("type")
+    const method = request.getDataValue("method")
+    const function_type = request.getDataValue("function_type")
+
+    let body = fs.readFileSync(`./requests/${id}_${method}_${type}.json`, {encoding:'utf8', flag:'r'} )
+    body = JSON.parse(body)
+    
+    require(`../utils/${type}.ts`)[function_type](body)
+}
+
 export const updateRequest = async (id:string | number, status: string) => {
     let request = await Request.findByPk(id)
+    if(request){
 
-    request?.update({status})
+        request.update({status})
+        
+        if(status === "accepted") executeRequest(request)
+    }
 }


### PR DESCRIPTION
Se añadió nuevas rutas para el modelo Request

POST /request (protegida, solo para Usuarios y en adelante): Crea una request

body:
![image](https://user-images.githubusercontent.com/57416193/175159290-e1b83820-2b78-4154-9300-2005ddbdda24.png)

para la parte de "information" esto va a variar mucho según el tipo de petición

PUT /request/:id (protegida, solo para Admins): updatea el status de una petición y ejecuta automaticamente la petición

![image](https://user-images.githubusercontent.com/57416193/175160172-91392171-ae41-4ad1-b9ff-00a89b006ffb.png)

"status": solo puede recibir "accepted" o "rejected"

GET /request/:id (protegida, solo para Admins): trae la información de una petición por id