### PR TITLE
refactor(api/iutils/process-payment): now can send multiple mails

### DIFF
--- a/api/src/mailer/index.ts
+++ b/api/src/mailer/index.ts
@@ -19,7 +19,6 @@ export const buildMail = (mail: any) => {
 
 export const sendMail = async (mail: any) => {
   mail  = buildMail(mail)
-  console.log(mail)
   try{
     await transporter.sendMail(mail, (err: any, info: any) => {
       if (err) {

--- a/api/src/models/Ticket.ts
+++ b/api/src/models/Ticket.ts
@@ -1,4 +1,4 @@
-import {Model, Column, Table, BelongsTo, ForeignKey, DataType} from 'sequelize-typescript';
+import {Model, Column, Table, BelongsTo, ForeignKey, DataType, Default} from 'sequelize-typescript';
 import { Event } from './Event';
 import { User } from './User';
 
@@ -31,6 +31,14 @@ export class Ticket extends Model<Ticket> {
 
     @Column
     date!: string
+
+    @Default(false)
+    @Column
+    confirmation_email!: boolean
+
+    @Default(false)
+    @Column
+    ticket_email!: boolean
     
     @ForeignKey(() => Event)
     @Column

--- a/api/src/utils/process-payment.ts
+++ b/api/src/utils/process-payment.ts
@@ -1,4 +1,5 @@
 import mercadopago from "mercadopago"
+import { Model } from "sequelize"
 import config from "../../config"
 import { sequelize } from "../db"
 import { sendMail } from "../mailer"
@@ -40,7 +41,7 @@ export const updatePaymentById = async(preferenceId: string, paymentId: string) 
 
     const {body}  = await mercadopago.payment.findById(Number(paymentId))
 
-    let ticket = await Ticket.findOne({
+    let tickets = await Ticket.findAll({
       include:[
         {
           model: User,
@@ -55,56 +56,73 @@ export const updatePaymentById = async(preferenceId: string, paymentId: string) 
         preferenceId
       }
     })
+    let flag = false
+    tickets.forEach(async (ticket: Model<any>)=> {
 
-    ticket?.update({status: body.status , status_detail: body.status_detail , paymentId , paymentType: body.payment_type_id})
 
-    const userMail = ticket?.getDataValue("user").getDataValue("email")
-    // approved, rejected, in_process, pending
-    const mailTicket = {
-      ticketId: ticket?.getDataValue("id"),
-      eventName: ticket?.getDataValue('event').getDataValue('name'), 
-      paymentId: ticket?.getDataValue('paymentId'),
-      paymentType: ticket?.getDataValue('paymentType'),
-      quantity: ticket?.getDataValue('quantity'),
-      buyerName: ticket?.getDataValue('user').getDataValue('name'),
-    }
-    let text: string;
-    switch(body.status){
-      case 'approved':
-        text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago ha sido aprobado. Dentro de unos minutos te estaremos enviando el ticket del evento.`
-        break;
-      case 'rejected':
-        text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago ha sido rechazado. Por favor, intenta nuevamente en unos minutos.`
-        break;
-      case 'in_process':
-        text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago está en proceso. Por favor, espera unos minutos y te llegará un mail con más información.`
-        break;
-      case 'pending':
-        text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago está pendiente. Una vez realizado el pago en ${body.payment_method_id} recibiras tu entrada.`
-        break;
-      default:
-        text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago ha sido procesado. Dentro de unos minutos te estaremos enviando el ticket del evento.`
-    }
+      ticket.update({status: body.status , status_detail: body.status_detail , paymentId , paymentType: body.payment_type_id})
+    
+      let mailOptions
+      const userMail = ticket?.getDataValue("user").getDataValue("email")
+      // approved, rejected, in_process, pending
+      const mailTicket = {
+        ticketId: ticket?.getDataValue("id"),
+        eventName: ticket?.getDataValue('event').getDataValue('name'), 
+        paymentId: ticket?.getDataValue('paymentId'),
+        paymentType: ticket?.getDataValue('paymentType'),
+        quantity: ticket?.getDataValue('quantity'),
+        buyerName: ticket?.getDataValue('user').getDataValue('name'),
+        date: ticket.getDataValue("date"),
+        location: ticket.getDataValue("location")
+      }
+      let text: string;
+      let confirmation_email = ticket.getDataValue("confirmation_email")
 
-    let mailOptions = {
-      to: userMail,
-      subject: 'Recibimos tu pago en YoVoy',
-      text
-    }
-    sendMail(mailOptions)
-    if (body.status === 'approved'){
-      mailOptions = {
-        to: userMail,
-        subject: '¡Tu pago ha sido aprobado! Aqui esta tu ticket para el evento',
-        text: `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago ha sido aprobado. Aqui esta tu ticket para el evento:
+      if(!confirmation_email && !flag){
+        switch(body.status){
+          case 'approved':
+            text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago ha sido aprobado. Dentro de unos minutos te estaremos enviando el ticket del evento.`
+            break;
+          case 'rejected':
+            text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago ha sido rechazado. Por favor, intenta nuevamente en unos minutos.`
+            break;
+          case 'in_process':
+            text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago está en proceso. Por favor, espera unos minutos y te llegará un mail con más información.`
+            break;
+          case 'pending':
+            text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago está pendiente. Una vez realizado el pago en ${body.payment_method_id} recibiras tu entrada.`
+            break;
+          default:
+            text = `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago ha sido procesado. Dentro de unos minutos te estaremos enviando el ticket del evento.`
+        }
+            
+        mailOptions = {
+          to: userMail,
+          subject: 'Recibimos tu pago en YoVoy',
+          text
+        }
+        sendMail(mailOptions)
+        Ticket.update({confirmation_email: true}, {where:{preferenceId}})
+        flag = true
+      }
+      let ticket_email = ticket.getDataValue("ticket_email")
+      if (body.status === 'approved' && !ticket_email ){
+        mailOptions = {
+          to: userMail,
+          subject: '¡Tu pago ha sido aprobado! Aqui esta tu ticket para el evento',
+          text: `Hola ${ticket?.getDataValue("user").getDataValue("name")}, tu pago ha sido aprobado. Aqui esta tu ticket para el evento:
           Evento: ${mailTicket.eventName}
+          Lugar: ${mailTicket.location}
+          Fecha: ${mailTicket.date}
           Comprador: ${mailTicket.buyerName}
           Id de Ticket: ${mailTicket.ticketId}
           Id de pago: ${mailTicket.paymentId}
           Tipo de pago: ${mailTicket.paymentType}
           Cantidad: ${mailTicket.quantity}
           `
+        }
+        sendMail(mailOptions)
+        ticket.update({ticket_email: true})
       }
-      sendMail(mailOptions)
-    }
+    })
 }


### PR DESCRIPTION
Ahora al procesarse el pago si se acepta va a mandar siempre 1 solo email de confirmación y tantos emails segun la cantidad de tickets de distintos eventos haya comprado el usuario